### PR TITLE
Issue 1 - findFromCompound looks for a record using incorrect query

### DIFF
--- a/lib/Traits/WithDatastoreHandlerMethods.php
+++ b/lib/Traits/WithDatastoreHandlerMethods.php
@@ -386,11 +386,16 @@ trait WithDatastoreHandlerMethods
             $this->getCacheContextForItem($ids),
             function () use ($ids) {
                 $clauseBuilder = (clone $this->serviceProvider->clauseBuilder)->reset()->useTable($this->table);
+
+                foreach($ids as $key => $id){
+                    $clauseBuilder->andWhere($key, '=', $id);
+                }
+
                 $items = $this->serviceProvider->queryStrategy->query(
                     $this->serviceProvider->queryBuilder
                         ->select('*')
                         ->from($this->table)
-                        ->where($clauseBuilder->andWhere($this->table->getFieldsForIdentity(), 'IN', $ids))
+                        ->where($clauseBuilder)
                         ->limit(1)
                 );
 


### PR DESCRIPTION
## Summary

Fixes an issue that caused `findFromCompound` to occasionally show the wrong record from a compound ID.

Resolves #1 
