### PR TITLE
Remove getModels suppression and enrich identity misses

### DIFF
--- a/lib/Traits/WithDatastoreHandlerMethods.php
+++ b/lib/Traits/WithDatastoreHandlerMethods.php
@@ -150,7 +150,7 @@ trait WithDatastoreHandlerMethods
 
         $ids = $this->serviceProvider->queryStrategy->insert($this->table, $attributes);
 
-        $result = Arr::first($this->getModels([$ids], false));
+        $result = Arr::first($this->getModels([$ids]));
 
         if(!$result){
             throw new DatastoreErrorException('Failed to create the record');
@@ -334,10 +334,9 @@ trait WithDatastoreHandlerMethods
      * Gets the models from the specified list of IDs.
      *
      * @param array<string, int>[] $ids
-     * @param bool $suppressDatastoreErrors When true, logs and degrades query failures to an empty list.
      * @return array
      */
-    protected function getModels(array $ids, bool $suppressDatastoreErrors = true): array
+    protected function getModels(array $ids): array
     {
         // Filter out the items that are currently in the cache.
         $idsToQuery = Arr::filter(
@@ -346,23 +345,14 @@ trait WithDatastoreHandlerMethods
         );
 
         if (!empty($idsToQuery)) {
-            try {
-                $clauseBuilder = (clone $this->serviceProvider->clauseBuilder)->reset()->useTable($this->table);
-                // Get the things that aren't in the cache.
-                $data = $this->serviceProvider->queryStrategy->query(
-                    $this->serviceProvider->queryBuilder
-                        ->from($this->table)
-                        ->select('*')
-                        ->where($clauseBuilder->andWhere($this->table->getFieldsForIdentity(), 'IN', ...$idsToQuery))
-                );
-            } catch (DatastoreErrorException $e) {
-                if (!$suppressDatastoreErrors) {
-                    throw $e;
-                }
-
-                $this->serviceProvider->loggerStrategy->logException($e, 'Could not get by IDs');
-                return [];
-            }
+            $clauseBuilder = (clone $this->serviceProvider->clauseBuilder)->reset()->useTable($this->table);
+            // Get the things that aren't in the cache.
+            $data = $this->serviceProvider->queryStrategy->query(
+                $this->serviceProvider->queryBuilder
+                    ->from($this->table)
+                    ->select('*')
+                    ->where($clauseBuilder->andWhere($this->table->getFieldsForIdentity(), 'IN', ...$idsToQuery))
+            );
 
             // Cache those items.
             $this->cacheItems($this->hydrateItems($data));
@@ -405,7 +395,11 @@ trait WithDatastoreHandlerMethods
                 $item = Arr::get($items, 0);
 
                 if (!$item) {
-                    throw new RecordNotFoundException('Record not found using the provided identity');
+                    throw new RecordNotFoundException(sprintf(
+                        'Record not found in table "%s" using identity %s.',
+                        $this->table->getName(),
+                        $this->encodeExceptionContext($ids)
+                    ));
                 }
 
                 return $this->modelAdapter->toModel($item);
@@ -542,5 +536,15 @@ trait WithDatastoreHandlerMethods
         if (!empty($duplicates)) {
             throw new DuplicateEntryException('Database operation stopped early because duplicate entries were detected.');
         }
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    protected function encodeExceptionContext(array $context): string
+    {
+        $encoded = json_encode($context, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        return $encoded === false ? '[unserializable context]' : $encoded;
     }
 }

--- a/lib/Traits/WithDatastoreHandlerMethods.php
+++ b/lib/Traits/WithDatastoreHandlerMethods.php
@@ -150,13 +150,13 @@ trait WithDatastoreHandlerMethods
 
         $ids = $this->serviceProvider->queryStrategy->insert($this->table, $attributes);
 
-        $result = Arr::first($this->getModels([$ids]));
-
-        $this->serviceProvider->eventStrategy->broadcast(new RecordCreated($result));
+        $result = Arr::first($this->getModels([$ids], false));
 
         if(!$result){
             throw new DatastoreErrorException('Failed to create the record');
         }
+
+        $this->serviceProvider->eventStrategy->broadcast(new RecordCreated($result));
 
         return $result;
     }
@@ -334,9 +334,10 @@ trait WithDatastoreHandlerMethods
      * Gets the models from the specified list of IDs.
      *
      * @param array<string, int>[] $ids
+     * @param bool $suppressDatastoreErrors When true, logs and degrades query failures to an empty list.
      * @return array
      */
-    protected function getModels(array $ids): array
+    protected function getModels(array $ids, bool $suppressDatastoreErrors = true): array
     {
         // Filter out the items that are currently in the cache.
         $idsToQuery = Arr::filter(
@@ -355,6 +356,10 @@ trait WithDatastoreHandlerMethods
                         ->where($clauseBuilder->andWhere($this->table->getFieldsForIdentity(), 'IN', ...$idsToQuery))
                 );
             } catch (DatastoreErrorException $e) {
+                if (!$suppressDatastoreErrors) {
+                    throw $e;
+                }
+
                 $this->serviceProvider->loggerStrategy->logException($e, 'Could not get by IDs');
                 return [];
             }

--- a/tests/Unit/Traits/WithDatastoreHandlerMethodsTest.php
+++ b/tests/Unit/Traits/WithDatastoreHandlerMethodsTest.php
@@ -27,6 +27,7 @@ use PHPNomad\Database\Services\TableSchemaService;
 use PHPNomad\Database\Tests\TestCase;
 use PHPNomad\Database\Traits\WithDatastoreHandlerMethods;
 use PHPNomad\Datastore\Exceptions\DatastoreErrorException;
+use PHPNomad\Datastore\Exceptions\RecordNotFoundException;
 use PHPNomad\Datastore\Interfaces\DataModel;
 use PHPNomad\Datastore\Interfaces\HasSingleIntIdentity;
 use PHPNomad\Datastore\Interfaces\ModelAdapter;
@@ -88,6 +89,51 @@ class WithDatastoreHandlerMethodsTest extends TestCase
 
         $handler->create(['name' => 'Example']);
     }
+
+    public function testFindFromCompoundIncludesTableAndIdentityWhenRecordIsMissing(): void
+    {
+        $queryStrategy = $this->createMock(QueryStrategy::class);
+        $queryStrategy->expects($this->once())
+            ->method('query')
+            ->willReturn([]);
+
+        $loggerStrategy = $this->createMock(LoggerStrategy::class);
+        $eventStrategy = $this->createMock(EventStrategy::class);
+
+        $cacheableService = $this->createMock(CacheableService::class);
+        $cacheableService->expects($this->once())
+            ->method('getWithCache')
+            ->willReturnCallback(fn(string $operation, array $context, callable $callback) => $callback());
+
+        $table = $this->createMock(Table::class);
+        $table->method('getName')->willReturn('test_records');
+
+        $tableSchemaService = $this->createMock(TableSchemaService::class);
+        $modelAdapter = $this->createMock(ModelAdapter::class);
+
+        $serviceProvider = new DatabaseServiceProvider(
+            $loggerStrategy,
+            $queryStrategy,
+            new DummyQueryBuilder(),
+            new DummyClauseBuilder(),
+            $cacheableService,
+            $eventStrategy
+        );
+
+        $handler = new DummyDatastoreHandler(
+            $serviceProvider,
+            $table,
+            $tableSchemaService,
+            TestModel::class,
+            $modelAdapter
+        );
+
+        $this->expectException(RecordNotFoundException::class);
+        $this->expectExceptionMessage('Record not found in table "test_records"');
+        $this->expectExceptionMessage('"id":123');
+
+        $handler->findByIdentity(['id' => 123]);
+    }
 }
 
 class DummyDatastoreHandler
@@ -106,6 +152,11 @@ class DummyDatastoreHandler
         $this->tableSchemaService = $tableSchemaService;
         $this->model = $model;
         $this->modelAdapter = $modelAdapter;
+    }
+
+    public function findByIdentity(array $ids)
+    {
+        return $this->findFromCompound($ids);
     }
 }
 

--- a/tests/Unit/Traits/WithDatastoreHandlerMethodsTest.php
+++ b/tests/Unit/Traits/WithDatastoreHandlerMethodsTest.php
@@ -1,0 +1,254 @@
+<?php
+
+namespace PHPNomad\Events\Interfaces {
+    if (!interface_exists(Event::class)) {
+        interface Event
+        {
+        }
+    }
+
+    if (!interface_exists(EventStrategy::class)) {
+        interface EventStrategy
+        {
+            public function broadcast(Event $event): void;
+        }
+    }
+}
+
+namespace PHPNomad\Database\Tests\Unit\Traits {
+
+use PHPNomad\Cache\Services\CacheableService;
+use PHPNomad\Database\Interfaces\ClauseBuilder;
+use PHPNomad\Database\Interfaces\QueryBuilder;
+use PHPNomad\Database\Interfaces\QueryStrategy;
+use PHPNomad\Database\Interfaces\Table;
+use PHPNomad\Database\Providers\DatabaseServiceProvider;
+use PHPNomad\Database\Services\TableSchemaService;
+use PHPNomad\Database\Tests\TestCase;
+use PHPNomad\Database\Traits\WithDatastoreHandlerMethods;
+use PHPNomad\Datastore\Exceptions\DatastoreErrorException;
+use PHPNomad\Datastore\Interfaces\DataModel;
+use PHPNomad\Datastore\Interfaces\HasSingleIntIdentity;
+use PHPNomad\Datastore\Interfaces\ModelAdapter;
+use PHPNomad\Events\Interfaces\EventStrategy;
+use PHPNomad\Logger\Interfaces\LoggerStrategy;
+
+class WithDatastoreHandlerMethodsTest extends TestCase
+{
+    public function testCreateRethrowsDatastoreErrorsFromPostInsertReread(): void
+    {
+        $queryStrategy = $this->createMock(QueryStrategy::class);
+        $queryStrategy->expects($this->once())
+            ->method('insert')
+            ->willReturn(['id' => 123]);
+        $queryStrategy->expects($this->once())
+            ->method('query')
+            ->willThrowException(new DatastoreErrorException('Replica read failed'));
+
+        $loggerStrategy = $this->createMock(LoggerStrategy::class);
+        $loggerStrategy->expects($this->never())
+            ->method('logException');
+
+        $eventStrategy = $this->createMock(EventStrategy::class);
+        $eventStrategy->expects($this->never())
+            ->method('broadcast');
+
+        $cacheableService = $this->createMock(CacheableService::class);
+        $cacheableService->expects($this->once())
+            ->method('exists')
+            ->willReturn(false);
+
+        $table = $this->createMock(Table::class);
+        $table->method('getFieldsForIdentity')->willReturn(['id']);
+
+        $tableSchemaService = $this->createMock(TableSchemaService::class);
+        $tableSchemaService->method('getUniqueColumns')->willReturn([]);
+
+        $modelAdapter = $this->createMock(ModelAdapter::class);
+
+        $serviceProvider = new DatabaseServiceProvider(
+            $loggerStrategy,
+            $queryStrategy,
+            new DummyQueryBuilder(),
+            new DummyClauseBuilder(),
+            $cacheableService,
+            $eventStrategy
+        );
+
+        $handler = new DummyDatastoreHandler(
+            $serviceProvider,
+            $table,
+            $tableSchemaService,
+            TestModel::class,
+            $modelAdapter
+        );
+
+        $this->expectException(DatastoreErrorException::class);
+        $this->expectExceptionMessage('Replica read failed');
+
+        $handler->create(['name' => 'Example']);
+    }
+}
+
+class DummyDatastoreHandler
+{
+    use WithDatastoreHandlerMethods;
+
+    public function __construct(
+        DatabaseServiceProvider $serviceProvider,
+        Table $table,
+        TableSchemaService $tableSchemaService,
+        string $model,
+        ModelAdapter $modelAdapter
+    ) {
+        $this->serviceProvider = $serviceProvider;
+        $this->table = $table;
+        $this->tableSchemaService = $tableSchemaService;
+        $this->model = $model;
+        $this->modelAdapter = $modelAdapter;
+    }
+}
+
+class TestModel implements DataModel, HasSingleIntIdentity
+{
+    public function __construct(private int $id = 1)
+    {
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getIdentity(): array
+    {
+        return ['id' => $this->id];
+    }
+}
+
+class DummyQueryBuilder implements QueryBuilder
+{
+    public function useTable(Table $table)
+    {
+        return $this;
+    }
+
+    public function select(string $field, string ...$fields)
+    {
+        return $this;
+    }
+
+    public function from(Table $table)
+    {
+        return $this;
+    }
+
+    public function where(?ClauseBuilder $clauseBuilder)
+    {
+        return $this;
+    }
+
+    public function leftJoin(Table $table, string $column, string $onColumn)
+    {
+        return $this;
+    }
+
+    public function rightJoin(Table $table, string $column, string $onColumn)
+    {
+        return $this;
+    }
+
+    public function groupBy(string $column, string ...$columns)
+    {
+        return $this;
+    }
+
+    public function sum(string $fieldToSum, ?string $alias = null)
+    {
+        return $this;
+    }
+
+    public function count(string $fieldToCount, ?string $alias = null)
+    {
+        return $this;
+    }
+
+    public function limit(int $limit)
+    {
+        return $this;
+    }
+
+    public function offset(int $offset)
+    {
+        return $this;
+    }
+
+    public function orderBy(string $field, string $order)
+    {
+        return $this;
+    }
+
+    public function build(): string
+    {
+        return 'SELECT * FROM test_table';
+    }
+
+    public function reset()
+    {
+        return $this;
+    }
+
+    public function resetClauses(string $clause, string ...$clauses)
+    {
+        return $this;
+    }
+}
+
+class DummyClauseBuilder implements ClauseBuilder
+{
+    public function useTable(Table $table)
+    {
+        return $this;
+    }
+
+    public function where($field, string $operator, ...$values)
+    {
+        return $this;
+    }
+
+    public function andWhere($field, string $operator, ...$values)
+    {
+        return $this;
+    }
+
+    public function orWhere($field, string $operator, ...$values)
+    {
+        return $this;
+    }
+
+    public function group(string $logic, ClauseBuilder ...$clauses)
+    {
+        return $this;
+    }
+
+    public function andGroup(string $logic, ClauseBuilder ...$clauses)
+    {
+        return $this;
+    }
+
+    public function orGroup(string $logic, ClauseBuilder ...$clauses)
+    {
+        return $this;
+    }
+
+    public function build(): string
+    {
+        return 'id = 123';
+    }
+
+    public function reset()
+    {
+        return $this;
+    }
+}
+}


### PR DESCRIPTION
## Summary
- remove the `getModels()` suppression path so datastore reread failures throw directly
- keep `create()` from degrading reread failures into follow-on null states
- enrich compound-identity misses with the table name and requested identity payload
- add unit coverage for the reread failure and missing-record identity paths

## Why
The hidden obligation failure on Siren showed that swallowing datastore reread errors was the wrong behavior. If the reread fails, that should be the failure. And if an identity lookup misses, the exception should say which table and identity were involved.

## Testing
- `vendor/bin/phpunit tests/Unit/Traits/WithDatastoreHandlerMethodsTest.php`