### PR TITLE
[codex] Create models from inserted identity

### DIFF
--- a/lib/Traits/WithDatastoreHandlerMethods.php
+++ b/lib/Traits/WithDatastoreHandlerMethods.php
@@ -149,16 +149,25 @@ trait WithDatastoreHandlerMethods
         $this->maybeThrowForDuplicateUniqueFields($attributes);
 
         $ids = $this->serviceProvider->queryStrategy->insert($this->table, $attributes);
-
-        $result = Arr::first($this->getModels([$ids]));
-
-        if(!$result){
-            throw new DatastoreErrorException('Failed to create the record');
-        }
+        $result = $this->getCreatedModelFromInsertedAttributes($attributes, $ids);
 
         $this->serviceProvider->eventStrategy->broadcast(new RecordCreated($result));
 
         return $result;
+    }
+
+    /**
+     * Builds the newly-created model from the inserted attributes and resolved
+     * identity, matching WordPress' pattern of trusting the insert identity
+     * instead of immediately querying the database again.
+     *
+     * @param array<string, mixed> $attributes
+     * @param array<string, int> $ids
+     * @return DataModel
+     */
+    protected function getCreatedModelFromInsertedAttributes(array $attributes, array $ids): DataModel
+    {
+        return $this->modelAdapter->toModel(array_merge($attributes, $ids));
     }
 
     /**

--- a/tests/Unit/Traits/WithDatastoreHandlerMethodsTest.php
+++ b/tests/Unit/Traits/WithDatastoreHandlerMethodsTest.php
@@ -26,6 +26,7 @@ use PHPNomad\Database\Providers\DatabaseServiceProvider;
 use PHPNomad\Database\Services\TableSchemaService;
 use PHPNomad\Database\Tests\TestCase;
 use PHPNomad\Database\Traits\WithDatastoreHandlerMethods;
+use PHPNomad\Datastore\Events\RecordCreated;
 use PHPNomad\Datastore\Exceptions\DatastoreErrorException;
 use PHPNomad\Datastore\Exceptions\RecordNotFoundException;
 use PHPNomad\Datastore\Interfaces\DataModel;
@@ -36,15 +37,140 @@ use PHPNomad\Logger\Interfaces\LoggerStrategy;
 
 class WithDatastoreHandlerMethodsTest extends TestCase
 {
-    public function testCreateRethrowsDatastoreErrorsFromPostInsertReread(): void
+    public function testCreateHydratesCreatedModelFromInsertedAttributesWithoutReadback(): void
+    {
+        $createdModel = new TestModel(123);
+
+        $queryStrategy = $this->createMock(QueryStrategy::class);
+        $queryStrategy->expects($this->once())
+            ->method('insert')
+            ->with($this->anything(), ['name' => 'Example'])
+            ->willReturn(['id' => 123]);
+        $queryStrategy->expects($this->never())
+            ->method('query');
+
+        $loggerStrategy = $this->createMock(LoggerStrategy::class);
+        $loggerStrategy->expects($this->never())
+            ->method('logException');
+
+        $eventStrategy = $this->createMock(EventStrategy::class);
+        $eventStrategy->expects($this->once())
+            ->method('broadcast')
+            ->with($this->callback(
+                fn($event) => $event instanceof RecordCreated && $event->getRecord() === $createdModel
+            ));
+
+        $cacheableService = $this->createMock(CacheableService::class);
+        $cacheableService->expects($this->never())
+            ->method('exists');
+        $cacheableService->expects($this->never())
+            ->method('set');
+        $cacheableService->expects($this->never())
+            ->method('getWithCache');
+
+        $table = $this->createMock(Table::class);
+        $table->method('getFieldsForIdentity')->willReturn(['id']);
+
+        $tableSchemaService = $this->createMock(TableSchemaService::class);
+        $tableSchemaService->method('getUniqueColumns')->willReturn([]);
+
+        $modelAdapter = $this->createMock(ModelAdapter::class);
+        $modelAdapter->expects($this->once())
+            ->method('toModel')
+            ->with(['name' => 'Example', 'id' => 123])
+            ->willReturn($createdModel);
+
+        $serviceProvider = new DatabaseServiceProvider(
+            $loggerStrategy,
+            $queryStrategy,
+            new DummyQueryBuilder(),
+            new DummyClauseBuilder(),
+            $cacheableService,
+            $eventStrategy
+        );
+
+        $handler = new DummyDatastoreHandler(
+            $serviceProvider,
+            $table,
+            $tableSchemaService,
+            TestModel::class,
+            $modelAdapter
+        );
+
+        $this->assertSame($createdModel, $handler->create(['name' => 'Example']));
+    }
+
+    public function testCreateRemovesProvidedAutoIncrementIdentityBeforeInsertAndUsesResolvedIdentity(): void
+    {
+        $createdModel = new TestModel(123);
+
+        $queryStrategy = $this->createMock(QueryStrategy::class);
+        $queryStrategy->expects($this->once())
+            ->method('insert')
+            ->with($this->anything(), ['name' => 'Example'])
+            ->willReturn(['id' => 123]);
+        $queryStrategy->expects($this->never())
+            ->method('query');
+
+        $loggerStrategy = $this->createMock(LoggerStrategy::class);
+        $loggerStrategy->expects($this->never())
+            ->method('logException');
+
+        $eventStrategy = $this->createMock(EventStrategy::class);
+        $eventStrategy->expects($this->once())
+            ->method('broadcast')
+            ->with($this->callback(
+                fn($event) => $event instanceof RecordCreated && $event->getRecord() === $createdModel
+            ));
+
+        $cacheableService = $this->createMock(CacheableService::class);
+        $cacheableService->expects($this->never())
+            ->method('exists');
+        $cacheableService->expects($this->never())
+            ->method('set');
+        $cacheableService->expects($this->never())
+            ->method('getWithCache');
+
+        $table = $this->createMock(Table::class);
+        $table->method('getFieldsForIdentity')->willReturn(['id']);
+
+        $tableSchemaService = $this->createMock(TableSchemaService::class);
+        $tableSchemaService->method('getUniqueColumns')->willReturn([]);
+
+        $modelAdapter = $this->createMock(ModelAdapter::class);
+        $modelAdapter->expects($this->once())
+            ->method('toModel')
+            ->with(['name' => 'Example', 'id' => 123])
+            ->willReturn($createdModel);
+
+        $serviceProvider = new DatabaseServiceProvider(
+            $loggerStrategy,
+            $queryStrategy,
+            new DummyQueryBuilder(),
+            new DummyClauseBuilder(),
+            $cacheableService,
+            $eventStrategy
+        );
+
+        $handler = new DummyDatastoreHandler(
+            $serviceProvider,
+            $table,
+            $tableSchemaService,
+            TestModel::class,
+            $modelAdapter
+        );
+
+        $this->assertSame($createdModel, $handler->create(['id' => 999, 'name' => 'Example']));
+    }
+
+    public function testCreateRethrowsDatastoreErrorsFromInsert(): void
     {
         $queryStrategy = $this->createMock(QueryStrategy::class);
         $queryStrategy->expects($this->once())
             ->method('insert')
-            ->willReturn(['id' => 123]);
-        $queryStrategy->expects($this->once())
-            ->method('query')
-            ->willThrowException(new DatastoreErrorException('Replica read failed'));
+            ->willThrowException(new DatastoreErrorException('Insert failed'));
+        $queryStrategy->expects($this->never())
+            ->method('query');
 
         $loggerStrategy = $this->createMock(LoggerStrategy::class);
         $loggerStrategy->expects($this->never())
@@ -55,9 +181,8 @@ class WithDatastoreHandlerMethodsTest extends TestCase
             ->method('broadcast');
 
         $cacheableService = $this->createMock(CacheableService::class);
-        $cacheableService->expects($this->once())
-            ->method('exists')
-            ->willReturn(false);
+        $cacheableService->expects($this->never())
+            ->method('exists');
 
         $table = $this->createMock(Table::class);
         $table->method('getFieldsForIdentity')->willReturn(['id']);
@@ -85,7 +210,7 @@ class WithDatastoreHandlerMethodsTest extends TestCase
         );
 
         $this->expectException(DatastoreErrorException::class);
-        $this->expectExceptionMessage('Replica read failed');
+        $this->expectExceptionMessage('Insert failed');
 
         $handler->create(['name' => 'Example']);
     }


### PR DESCRIPTION
## Summary
- Change `create()` to build the returned model from the attributes PHPNomad inserted plus the identity returned by the write strategy.
- Remove the immediate post-insert readback from the generic create path.
- Update unit coverage to assert create does not query after insert and still broadcasts `RecordCreated` with the hydrated model.

## Why
WordPress' insert path calls `$wpdb->insert()`, reads `$wpdb->insert_id` from the same connection, and proceeds with that identity. It does not immediately re-query the inserted row as part of the insert contract. PHPNomad was doing that extra generic readback, which makes create sensitive to read-after-write visibility even when the write itself succeeded.

## Validation
- `vendor/bin/phpunit --testdox`
