### PR TITLE
[codex] Add write-consistent datastore hydration

### DIFF
--- a/lib/Interfaces/ConsistentReadQueryStrategy.php
+++ b/lib/Interfaces/ConsistentReadQueryStrategy.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace PHPNomad\Database\Interfaces;
+
+use PHPNomad\Datastore\Exceptions\DatastoreErrorException;
+
+interface ConsistentReadQueryStrategy
+{
+    /**
+     * Executes a database query through a read path that can see preceding writes.
+     *
+     * @param QueryBuilder $builder A fully-escaped query builder.
+     * @return array
+     * @throws DatastoreErrorException
+     */
+    public function queryConsistently(QueryBuilder $builder): array;
+}

--- a/lib/Traits/WithDatastoreHandlerMethods.php
+++ b/lib/Traits/WithDatastoreHandlerMethods.php
@@ -3,6 +3,8 @@
 namespace PHPNomad\Database\Traits;
 
 use PHPNomad\Cache\Enums\Operation;
+use PHPNomad\Database\Interfaces\ConsistentReadQueryStrategy;
+use PHPNomad\Database\Interfaces\QueryBuilder;
 use PHPNomad\Datastore\Events\RecordCreated;
 use PHPNomad\Datastore\Events\RecordDeleted;
 use PHPNomad\Datastore\Events\RecordUpdated;
@@ -150,7 +152,7 @@ trait WithDatastoreHandlerMethods
 
         $ids = $this->serviceProvider->queryStrategy->insert($this->table, $attributes);
 
-        $result = Arr::first($this->getModels([$ids]));
+        $result = Arr::first($this->getModels([$ids], true));
 
         if(!$result){
             throw new DatastoreErrorException('Failed to create the record');
@@ -334,25 +336,28 @@ trait WithDatastoreHandlerMethods
      * Gets the models from the specified list of IDs.
      *
      * @param array<string, int>[] $ids
+     * @param bool $consistent Whether the read must see preceding writes.
      * @return array
      */
-    protected function getModels(array $ids): array
+    protected function getModels(array $ids, bool $consistent = false): array
     {
         // Filter out the items that are currently in the cache.
-        $idsToQuery = Arr::filter(
-            $ids,
-            fn(array $ids) => !$this->serviceProvider->cacheableService->exists($this->getCacheContextForItem($ids))
-        );
+        $idsToQuery = $consistent
+            ? $ids
+            : Arr::filter(
+                $ids,
+                fn(array $ids) => !$this->serviceProvider->cacheableService->exists($this->getCacheContextForItem($ids))
+            );
 
         if (!empty($idsToQuery)) {
             $clauseBuilder = (clone $this->serviceProvider->clauseBuilder)->reset()->useTable($this->table);
             // Get the things that aren't in the cache.
-            $data = $this->serviceProvider->queryStrategy->query(
-                $this->serviceProvider->queryBuilder
-                    ->from($this->table)
-                    ->select('*')
-                    ->where($clauseBuilder->andWhere($this->table->getFieldsForIdentity(), 'IN', ...$idsToQuery))
-            );
+            $queryBuilder = $this->serviceProvider->queryBuilder
+                ->from($this->table)
+                ->select('*')
+                ->where($clauseBuilder->andWhere($this->table->getFieldsForIdentity(), 'IN', ...$idsToQuery));
+
+            $data = $this->queryModels($queryBuilder, $consistent);
 
             // Cache those items.
             $this->cacheItems($this->hydrateItems($data));
@@ -360,6 +365,23 @@ trait WithDatastoreHandlerMethods
 
         // Now, use the cache to get all the posts in the proper order.
         return Arr::map($ids, fn(array $id) => $this->findFromCompound($id));
+    }
+
+    /**
+     * Queries model rows, optionally using a write-consistent read strategy.
+     *
+     * @param QueryBuilder $queryBuilder
+     * @param bool $consistent
+     * @return array
+     * @throws DatastoreErrorException
+     */
+    protected function queryModels(QueryBuilder $queryBuilder, bool $consistent): array
+    {
+        if ($consistent && $this->serviceProvider->queryStrategy instanceof ConsistentReadQueryStrategy) {
+            return $this->serviceProvider->queryStrategy->queryConsistently($queryBuilder);
+        }
+
+        return $this->serviceProvider->queryStrategy->query($queryBuilder);
     }
 
     /**
@@ -415,6 +437,7 @@ trait WithDatastoreHandlerMethods
 
         $this->serviceProvider->queryStrategy->update($this->table, $ids, $attributes);
         $this->serviceProvider->cacheableService->delete($this->getCacheContextForItem($ids));
+        $this->getModels([$ids], true);
         $this->serviceProvider->eventStrategy->broadcast(new RecordUpdated($record::class, $ids, $attributes));
     }
 

--- a/tests/Unit/Traits/WithDatastoreHandlerMethodsTest.php
+++ b/tests/Unit/Traits/WithDatastoreHandlerMethodsTest.php
@@ -19,6 +19,7 @@ namespace PHPNomad\Database\Tests\Unit\Traits {
 
 use PHPNomad\Cache\Services\CacheableService;
 use PHPNomad\Database\Interfaces\ClauseBuilder;
+use PHPNomad\Database\Interfaces\ConsistentReadQueryStrategy;
 use PHPNomad\Database\Interfaces\QueryBuilder;
 use PHPNomad\Database\Interfaces\QueryStrategy;
 use PHPNomad\Database\Interfaces\Table;
@@ -36,6 +37,64 @@ use PHPNomad\Logger\Interfaces\LoggerStrategy;
 
 class WithDatastoreHandlerMethodsTest extends TestCase
 {
+    public function testCreateUsesConsistentReadStrategyForPostInsertHydration(): void
+    {
+        $queryStrategy = new ConsistentQueryStrategyStub();
+
+        $loggerStrategy = $this->createMock(LoggerStrategy::class);
+
+        $eventStrategy = $this->createMock(EventStrategy::class);
+        $eventStrategy->expects($this->once())
+            ->method('broadcast');
+
+        $createdModel = new TestModel(123);
+
+        $cacheableService = $this->createMock(CacheableService::class);
+        $cacheableService->expects($this->never())
+            ->method('exists');
+        $cacheableService->expects($this->once())
+            ->method('set')
+            ->with(['identities' => ['id' => 123], 'type' => TestModel::class], $createdModel);
+        $cacheableService->expects($this->once())
+            ->method('getWithCache')
+            ->willReturn($createdModel);
+
+        $table = $this->createMock(Table::class);
+        $table->method('getFieldsForIdentity')->willReturn(['id']);
+
+        $tableSchemaService = $this->createMock(TableSchemaService::class);
+        $tableSchemaService->method('getUniqueColumns')->willReturn([]);
+
+        $modelAdapter = $this->createMock(ModelAdapter::class);
+        $modelAdapter->expects($this->once())
+            ->method('toModel')
+            ->with(['id' => 123, 'name' => 'Example'])
+            ->willReturn($createdModel);
+
+        $serviceProvider = new DatabaseServiceProvider(
+            $loggerStrategy,
+            $queryStrategy,
+            new DummyQueryBuilder(),
+            new DummyClauseBuilder(),
+            $cacheableService,
+            $eventStrategy
+        );
+
+        $handler = new DummyDatastoreHandler(
+            $serviceProvider,
+            $table,
+            $tableSchemaService,
+            TestModel::class,
+            $modelAdapter
+        );
+
+        $result = $handler->create(['name' => 'Example']);
+
+        $this->assertSame($createdModel, $result);
+        $this->assertSame(0, $queryStrategy->queryCalls);
+        $this->assertSame(1, $queryStrategy->consistentQueryCalls);
+    }
+
     public function testCreateRethrowsDatastoreErrorsFromPostInsertReread(): void
     {
         $queryStrategy = $this->createMock(QueryStrategy::class);
@@ -55,9 +114,8 @@ class WithDatastoreHandlerMethodsTest extends TestCase
             ->method('broadcast');
 
         $cacheableService = $this->createMock(CacheableService::class);
-        $cacheableService->expects($this->once())
-            ->method('exists')
-            ->willReturn(false);
+        $cacheableService->expects($this->never())
+            ->method('exists');
 
         $table = $this->createMock(Table::class);
         $table->method('getFieldsForIdentity')->willReturn(['id']);
@@ -133,6 +191,44 @@ class WithDatastoreHandlerMethodsTest extends TestCase
         $this->expectExceptionMessage('"id":123');
 
         $handler->findByIdentity(['id' => 123]);
+    }
+}
+
+class ConsistentQueryStrategyStub implements QueryStrategy, ConsistentReadQueryStrategy
+{
+    public int $queryCalls = 0;
+    public int $consistentQueryCalls = 0;
+
+    public function query(QueryBuilder $builder): array
+    {
+        $this->queryCalls++;
+
+        throw new RecordNotFoundException('Stale reader did not return the inserted row.');
+    }
+
+    public function queryConsistently(QueryBuilder $builder): array
+    {
+        $this->consistentQueryCalls++;
+
+        return [['id' => 123, 'name' => 'Example']];
+    }
+
+    public function insert(Table $table, array $data): array
+    {
+        return ['id' => 123];
+    }
+
+    public function delete(Table $table, array $ids): void
+    {
+    }
+
+    public function update(Table $table, array $ids, array $data): void
+    {
+    }
+
+    public function estimatedCount(Table $table): int
+    {
+        return 0;
     }
 }
 


### PR DESCRIPTION
## What changed

This adds an optional `ConsistentReadQueryStrategy` capability to the database abstraction and uses it when datastore writes need to immediately hydrate or refresh a model.

Specifically:

- Added `PHPNomad\Database\Interfaces\ConsistentReadQueryStrategy` with `queryConsistently()`.
- Updated datastore `create()` so the post-insert hydration read asks for a write-consistent read.
- Updated `updateCompound()` to refresh the cache from a write-consistent read after the update.
- Kept the existing `QueryStrategy` contract intact. Integrations that do not implement the new optional capability continue to use the existing query path.

## Why

The datastore contract returns hydrated models from `create()`. That means the current flow is:

1. insert row
2. get inserted identity
3. immediately query the row back
4. hydrate/cache the model

On hosts with read/write splitting or asynchronous replicas, the immediate read can hit a stale reader even though the insert succeeded on the writer. That makes PHPNomad report a missing record after a successful insert.

This is the database-layer hook that lets each SQL integration provide a read path that can see its own writes.

## Impact

This avoids treating a successful write as a failed create just because an immediate replica read is stale. It also prevents stale data from being re-cached immediately after an update.

## Validation

- `vendor/bin/phpunit --testdox`
- Result: 4 tests, 17 assertions passing

## Related PRs

The SQL integrations implement this optional capability in companion PRs:

- `phpnomad/wordpress-integration`
- `phpnomad/mysql-db-integration`
- `phpnomad/safemysql-integration`
