### PR TITLE
Hydrate from attributes + ids on create() instead of post-insert read

### DIFF
--- a/lib/Factories/Column.php
+++ b/lib/Factories/Column.php
@@ -9,6 +9,11 @@ final class Column
     protected ?array $typeArgs = null;
     protected array $attributes = [];
 
+    /**
+     * @var callable|null
+     */
+    protected $phpDefault = null;
+
 	/**
 	 * @param string   $name
 	 * @param string   $type
@@ -59,5 +64,39 @@ final class Column
     public function getAttributes(): array
     {
         return $this->attributes;
+    }
+
+    /**
+     * Provides a PHP-side default value for this column.
+     *
+     * When set, the datastore layer fills in this value at create time for any
+     * insert that does not already include the column. The value flows into the
+     * INSERT and into the in-memory model that `create()` returns, which removes
+     * the need for a post-insert read-back to capture DB-generated defaults.
+     *
+     * Pair this with the matching DB-side DEFAULT (e.g. `DEFAULT CURRENT_TIMESTAMP`)
+     * for belt-and-suspenders coverage when rows are inserted outside the framework.
+     *
+     * The callable receives no arguments and should return a value already in the
+     * shape the column expects (e.g. a MySQL-format datetime string for a TIMESTAMP).
+     *
+     * @param callable():mixed $default
+     * @return self
+     */
+    public function withPhpDefault(callable $default): self
+    {
+        $this->phpDefault = $default;
+
+        return $this;
+    }
+
+    /**
+     * Returns the PHP-side default callable, or null if none is set.
+     *
+     * @return callable|null
+     */
+    public function getPhpDefault(): ?callable
+    {
+        return $this->phpDefault;
     }
 }

--- a/lib/Factories/Columns/DateCreatedFactory.php
+++ b/lib/Factories/Columns/DateCreatedFactory.php
@@ -2,6 +2,7 @@
 
 namespace PHPNomad\Database\Factories\Columns;
 
+use DateTimeImmutable;
 use PHPNomad\Database\Factories\Column;
 use PHPNomad\Database\Interfaces\CanConvertToColumn;
 
@@ -9,6 +10,7 @@ class DateCreatedFactory implements CanConvertToColumn
 {
     public function toColumn(): Column
     {
-        return new Column('dateCreated', 'TIMESTAMP', null, 'NOT NULL DEFAULT CURRENT_TIMESTAMP');
+        return (new Column('dateCreated', 'TIMESTAMP', null, 'NOT NULL DEFAULT CURRENT_TIMESTAMP'))
+            ->withPhpDefault(static fn (): string => (new DateTimeImmutable())->format('Y-m-d H:i:s'));
     }
 }

--- a/lib/Factories/Columns/DateModifiedFactory.php
+++ b/lib/Factories/Columns/DateModifiedFactory.php
@@ -2,6 +2,7 @@
 
 namespace PHPNomad\Database\Factories\Columns;
 
+use DateTimeImmutable;
 use PHPNomad\Database\Factories\Column;
 use PHPNomad\Database\Interfaces\CanConvertToColumn;
 
@@ -9,6 +10,7 @@ class DateModifiedFactory implements CanConvertToColumn
 {
     public function toColumn(): Column
     {
-        return new Column('dateModified','TIMESTAMP', null, 'NOT NULL DEFAULT CURRENT_TIMESTAMP');
+        return (new Column('dateModified', 'TIMESTAMP', null, 'NOT NULL DEFAULT CURRENT_TIMESTAMP'))
+            ->withPhpDefault(static fn (): string => (new DateTimeImmutable())->format('Y-m-d H:i:s'));
     }
 }

--- a/lib/Traits/WithDatastoreHandlerMethods.php
+++ b/lib/Traits/WithDatastoreHandlerMethods.php
@@ -148,17 +148,48 @@ trait WithDatastoreHandlerMethods
 
         $this->maybeThrowForDuplicateUniqueFields($attributes);
 
+        // Apply PHP-side defaults so the values that land in the DB also land
+        // in the in-memory model we hand back. This eliminates the post-insert
+        // read-back, which is the operation that races read-replicas behind a
+        // write/read-split router (ProxySQL, MaxScale, Aurora, etc.).
+        $attributes = $this->applyPhpDefaults($attributes);
+
         $ids = $this->serviceProvider->queryStrategy->insert($this->table, $attributes);
 
-        $result = Arr::first($this->getModels([$ids]));
+        $result = $this->modelAdapter->toModel(Arr::merge($attributes, $ids));
 
-        if(!$result){
-            throw new DatastoreErrorException('Failed to create the record');
-        }
+        // Pre-warm the cache so subsequent reads of this record don't have to
+        // round-trip the DB at all. Same key the framework's getModels() flow
+        // would have written, so existing read paths transparently pick it up.
+        $this->cacheItems([$result]);
 
         $this->serviceProvider->eventStrategy->broadcast(new RecordCreated($result));
 
         return $result;
+    }
+
+    /**
+     * Fills in PHP-side defaults for any column the table declares with a
+     * `phpDefault` callable that wasn't already supplied by the caller.
+     *
+     * @param array<string, mixed> $attributes
+     * @return array<string, mixed>
+     */
+    protected function applyPhpDefaults(array $attributes): array
+    {
+        foreach ($this->table->getColumns() as $column) {
+            $name = $column->getName();
+            if (array_key_exists($name, $attributes)) {
+                continue;
+            }
+            $default = $column->getPhpDefault();
+            if ($default === null) {
+                continue;
+            }
+            $attributes[$name] = $default();
+        }
+
+        return $attributes;
     }
 
     /**

--- a/tests/Unit/Factories/ColumnTest.php
+++ b/tests/Unit/Factories/ColumnTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace PHPNomad\Database\Tests\Unit\Factories;
+
+use PHPNomad\Database\Factories\Column;
+use PHPNomad\Database\Tests\TestCase;
+
+class ColumnTest extends TestCase
+{
+    public function testGetPhpDefaultIsNullByDefault(): void
+    {
+        $column = new Column('name', 'VARCHAR', [255]);
+
+        $this->assertNull($column->getPhpDefault());
+    }
+
+    public function testWithPhpDefaultStoresAndReturnsCallable(): void
+    {
+        $column = (new Column('createdAt', 'TIMESTAMP'))
+            ->withPhpDefault(static fn () => 'now');
+
+        $default = $column->getPhpDefault();
+
+        $this->assertIsCallable($default);
+        $this->assertSame('now', $default());
+    }
+
+    public function testWithPhpDefaultIsFluent(): void
+    {
+        $column = new Column('createdAt', 'TIMESTAMP');
+
+        $returned = $column->withPhpDefault(static fn () => 'now');
+
+        $this->assertSame($column, $returned);
+    }
+
+    public function testWithPhpDefaultDoesNotAffectOtherFields(): void
+    {
+        $column = (new Column('createdAt', 'TIMESTAMP', null, 'NOT NULL DEFAULT CURRENT_TIMESTAMP'))
+            ->withPhpDefault(static fn () => 'now');
+
+        $this->assertSame('createdAt', $column->getName());
+        $this->assertSame('TIMESTAMP', $column->getType());
+        $this->assertNull($column->getTypeArgs());
+        $this->assertSame(['NOT NULL DEFAULT CURRENT_TIMESTAMP'], $column->getAttributes());
+    }
+}

--- a/tests/Unit/Factories/Columns/DateCreatedFactoryTest.php
+++ b/tests/Unit/Factories/Columns/DateCreatedFactoryTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace PHPNomad\Database\Tests\Unit\Factories\Columns;
+
+use PHPNomad\Database\Factories\Columns\DateCreatedFactory;
+use PHPNomad\Database\Tests\TestCase;
+
+class DateCreatedFactoryTest extends TestCase
+{
+    public function testProducesDateCreatedColumnWithDbDefault(): void
+    {
+        $column = (new DateCreatedFactory())->toColumn();
+
+        $this->assertSame('dateCreated', $column->getName());
+        $this->assertSame('TIMESTAMP', $column->getType());
+        $this->assertSame(['NOT NULL DEFAULT CURRENT_TIMESTAMP'], $column->getAttributes());
+    }
+
+    public function testProvidesPhpDefaultThatReturnsMysqlFormatTimestamp(): void
+    {
+        $column = (new DateCreatedFactory())->toColumn();
+        $default = $column->getPhpDefault();
+
+        $this->assertIsCallable($default);
+
+        $value = $default();
+
+        $this->assertIsString($value);
+        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $value);
+    }
+}

--- a/tests/Unit/Factories/Columns/DateModifiedFactoryTest.php
+++ b/tests/Unit/Factories/Columns/DateModifiedFactoryTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace PHPNomad\Database\Tests\Unit\Factories\Columns;
+
+use PHPNomad\Database\Factories\Columns\DateModifiedFactory;
+use PHPNomad\Database\Tests\TestCase;
+
+class DateModifiedFactoryTest extends TestCase
+{
+    public function testProducesDateModifiedColumnWithDbDefault(): void
+    {
+        $column = (new DateModifiedFactory())->toColumn();
+
+        $this->assertSame('dateModified', $column->getName());
+        $this->assertSame('TIMESTAMP', $column->getType());
+        $this->assertSame(['NOT NULL DEFAULT CURRENT_TIMESTAMP'], $column->getAttributes());
+    }
+
+    public function testProvidesPhpDefaultThatReturnsMysqlFormatTimestamp(): void
+    {
+        $column = (new DateModifiedFactory())->toColumn();
+        $default = $column->getPhpDefault();
+
+        $this->assertIsCallable($default);
+
+        $value = $default();
+
+        $this->assertIsString($value);
+        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $value);
+    }
+}

--- a/tests/Unit/Traits/WithDatastoreHandlerMethodsTest.php
+++ b/tests/Unit/Traits/WithDatastoreHandlerMethodsTest.php
@@ -18,6 +18,7 @@ namespace PHPNomad\Events\Interfaces {
 namespace PHPNomad\Database\Tests\Unit\Traits {
 
 use PHPNomad\Cache\Services\CacheableService;
+use PHPNomad\Database\Factories\Column;
 use PHPNomad\Database\Interfaces\ClauseBuilder;
 use PHPNomad\Database\Interfaces\QueryBuilder;
 use PHPNomad\Database\Interfaces\QueryStrategy;
@@ -26,6 +27,7 @@ use PHPNomad\Database\Providers\DatabaseServiceProvider;
 use PHPNomad\Database\Services\TableSchemaService;
 use PHPNomad\Database\Tests\TestCase;
 use PHPNomad\Database\Traits\WithDatastoreHandlerMethods;
+use PHPNomad\Datastore\Events\RecordCreated;
 use PHPNomad\Datastore\Exceptions\DatastoreErrorException;
 use PHPNomad\Datastore\Exceptions\RecordNotFoundException;
 use PHPNomad\Datastore\Interfaces\DataModel;
@@ -36,36 +38,44 @@ use PHPNomad\Logger\Interfaces\LoggerStrategy;
 
 class WithDatastoreHandlerMethodsTest extends TestCase
 {
-    public function testCreateRethrowsDatastoreErrorsFromPostInsertReread(): void
+    public function testCreateHydratesFromAttributesWithoutPostInsertRead(): void
     {
         $queryStrategy = $this->createMock(QueryStrategy::class);
         $queryStrategy->expects($this->once())
             ->method('insert')
+            ->with($this->anything(), ['name' => 'Example'])
             ->willReturn(['id' => 123]);
-        $queryStrategy->expects($this->once())
-            ->method('query')
-            ->willThrowException(new DatastoreErrorException('Replica read failed'));
+        // Critical: no post-insert read. This is the operation that races
+        // read-replicas behind write/read-split routers.
+        $queryStrategy->expects($this->never())->method('query');
 
         $loggerStrategy = $this->createMock(LoggerStrategy::class);
-        $loggerStrategy->expects($this->never())
-            ->method('logException');
+
+        $createdModel = new TestModel(123);
 
         $eventStrategy = $this->createMock(EventStrategy::class);
-        $eventStrategy->expects($this->never())
-            ->method('broadcast');
+        $eventStrategy->expects($this->once())
+            ->method('broadcast')
+            ->with($this->isInstanceOf(RecordCreated::class));
 
         $cacheableService = $this->createMock(CacheableService::class);
+        $cacheableService->expects($this->never())->method('exists');
         $cacheableService->expects($this->once())
-            ->method('exists')
-            ->willReturn(false);
+            ->method('set')
+            ->with(['identities' => ['id' => 123], 'type' => TestModel::class], $createdModel);
 
         $table = $this->createMock(Table::class);
         $table->method('getFieldsForIdentity')->willReturn(['id']);
+        $table->method('getColumns')->willReturn([]);
 
         $tableSchemaService = $this->createMock(TableSchemaService::class);
         $tableSchemaService->method('getUniqueColumns')->willReturn([]);
 
         $modelAdapter = $this->createMock(ModelAdapter::class);
+        $modelAdapter->expects($this->once())
+            ->method('toModel')
+            ->with(['name' => 'Example', 'id' => 123])
+            ->willReturn($createdModel);
 
         $serviceProvider = new DatabaseServiceProvider(
             $loggerStrategy,
@@ -84,10 +94,117 @@ class WithDatastoreHandlerMethodsTest extends TestCase
             $modelAdapter
         );
 
-        $this->expectException(DatastoreErrorException::class);
-        $this->expectExceptionMessage('Replica read failed');
+        $result = $handler->create(['name' => 'Example']);
+
+        $this->assertSame($createdModel, $result);
+    }
+
+    public function testCreateAppliesPhpDefaultsForMissingColumns(): void
+    {
+        $queryStrategy = $this->createMock(QueryStrategy::class);
+        $queryStrategy->expects($this->once())
+            ->method('insert')
+            ->with($this->anything(), [
+                'name' => 'Example',
+                'createdAt' => 'php-default-value',
+            ])
+            ->willReturn(['id' => 123]);
+        $queryStrategy->expects($this->never())->method('query');
+
+        $loggerStrategy = $this->createMock(LoggerStrategy::class);
+        $eventStrategy = $this->createMock(EventStrategy::class);
+
+        $createdModel = new TestModel(123);
+
+        $cacheableService = $this->createMock(CacheableService::class);
+        $cacheableService->expects($this->once())->method('set');
+
+        $nameColumn = new Column('name', 'VARCHAR', [255]);
+        $createdAtColumn = (new Column('createdAt', 'TIMESTAMP'))
+            ->withPhpDefault(static fn () => 'php-default-value');
+
+        $table = $this->createMock(Table::class);
+        $table->method('getFieldsForIdentity')->willReturn(['id']);
+        $table->method('getColumns')->willReturn([$nameColumn, $createdAtColumn]);
+
+        $tableSchemaService = $this->createMock(TableSchemaService::class);
+        $tableSchemaService->method('getUniqueColumns')->willReturn([]);
+
+        $modelAdapter = $this->createMock(ModelAdapter::class);
+        $modelAdapter->expects($this->once())
+            ->method('toModel')
+            ->with([
+                'name' => 'Example',
+                'createdAt' => 'php-default-value',
+                'id' => 123,
+            ])
+            ->willReturn($createdModel);
+
+        $serviceProvider = new DatabaseServiceProvider(
+            $loggerStrategy,
+            $queryStrategy,
+            new DummyQueryBuilder(),
+            new DummyClauseBuilder(),
+            $cacheableService,
+            $eventStrategy
+        );
+
+        $handler = new DummyDatastoreHandler(
+            $serviceProvider,
+            $table,
+            $tableSchemaService,
+            TestModel::class,
+            $modelAdapter
+        );
 
         $handler->create(['name' => 'Example']);
+    }
+
+    public function testCreateRespectsCallerProvidedValuesOverPhpDefaults(): void
+    {
+        $queryStrategy = $this->createMock(QueryStrategy::class);
+        $queryStrategy->expects($this->once())
+            ->method('insert')
+            ->with($this->anything(), [
+                'createdAt' => 'caller-provided', // not php-default-value
+            ])
+            ->willReturn(['id' => 7]);
+
+        $loggerStrategy = $this->createMock(LoggerStrategy::class);
+        $eventStrategy = $this->createMock(EventStrategy::class);
+        $cacheableService = $this->createMock(CacheableService::class);
+
+        $createdAtColumn = (new Column('createdAt', 'TIMESTAMP'))
+            ->withPhpDefault(static fn () => 'php-default-value');
+
+        $table = $this->createMock(Table::class);
+        $table->method('getFieldsForIdentity')->willReturn(['id']);
+        $table->method('getColumns')->willReturn([$createdAtColumn]);
+
+        $tableSchemaService = $this->createMock(TableSchemaService::class);
+        $tableSchemaService->method('getUniqueColumns')->willReturn([]);
+
+        $modelAdapter = $this->createMock(ModelAdapter::class);
+        $modelAdapter->method('toModel')->willReturn(new TestModel(7));
+
+        $serviceProvider = new DatabaseServiceProvider(
+            $loggerStrategy,
+            $queryStrategy,
+            new DummyQueryBuilder(),
+            new DummyClauseBuilder(),
+            $cacheableService,
+            $eventStrategy
+        );
+
+        $handler = new DummyDatastoreHandler(
+            $serviceProvider,
+            $table,
+            $tableSchemaService,
+            TestModel::class,
+            $modelAdapter
+        );
+
+        $handler->create(['createdAt' => 'caller-provided']);
     }
 
     public function testFindFromCompoundIncludesTableAndIdentityWhenRecordIsMissing(): void


### PR DESCRIPTION
## Problem

`WithDatastoreHandlerMethods::create()` does an `INSERT` then immediately reads the row back to hydrate the returned model. On any host with a write/read-split router in front of MySQL/MariaDB (ProxySQL, MaxScale, RDS Proxy, Aurora, Cloudways Autonomous, etc.), the autocommit `INSERT` lands on master and the autocommit `SELECT` is allowed to be routed to a read-replica that hasn't yet received the write. The result is a `RecordNotFoundException` thrown from a successful insert.

This is a property of distributed systems, not of MariaDB specifically. Any future PHPNomad integration against an eventually-consistent backend (Postgres + pgpool, MongoDB with read preferences, Cassandra, Elasticsearch, REST behind a CDN) would exhibit the same failure shape.

## Production reproduction

Reproduced on a customer's actual production environment (Cloudways Autonomous, MariaDB 10.11.5 behind a routed K8s service):

| Mode | Failures | Notes |
|---|---|---|
| `baseline` (autocommit) | **7 / 500** | Today's framework code path |
| `txn_per_op` (autocommit) | 7 / 500 | |
| `big_txn` (`START TRANSACTION` … `COMMIT`) | 0 / 500 | |
| `read_uncommitted` (in txn) | 0 / 500 | |
| `serializable` (in txn) | 0 / 200 | |

Every failure had the same client-side `CONNECTION_ID()`, with `LAST_INSERT_ID()` returning the correct id, recovering within 10–50ms. The router pins clients to one backend during a transaction (mandatory for txn correctness), which is why every transactional mode passed cleanly.

## Approach

Most ORMs and platforms (WordPress core, Eloquent, Doctrine, ActiveRecord) avoid this race by *not* reading back after a write — they construct the model from the data the caller passed plus the new identity, and trust their in-memory representation. This PR brings PHPNomad in line with that pattern.

## What changed

### `Column` gains an optional `withPhpDefault()` setter

```php
$column = (new Column('createdAt', 'TIMESTAMP', null, 'NOT NULL DEFAULT CURRENT_TIMESTAMP'))
    ->withPhpDefault(static fn () => (new DateTimeImmutable())->format('Y-m-d H:i:s'));
```

The callable is invoked at `create()` time for any column the caller didn't provide. The DB-side `DEFAULT` stays in place as belt-and-suspenders for inserts that bypass the framework.

### `DateCreatedFactory` and `DateModifiedFactory` use it

Both factories now provide a `phpDefault` that returns the current MySQL-format timestamp. Existing column DDL is unchanged.

### `create()` hydrates from attributes + ids

```php
$attributes = $this->applyPhpDefaults($attributes);
$ids = $this->serviceProvider->queryStrategy->insert($this->table, $attributes);
$result = $this->modelAdapter->toModel(Arr::merge($attributes, $ids));
$this->cacheItems([$result]);
$this->serviceProvider->eventStrategy->broadcast(new RecordCreated($result));
```

No post-insert `SELECT`. The cache pre-warm lands the model under the same key the existing `getModels()` flow would have used, so subsequent reads transparently short-circuit through the cache.

## Contract change

Any column whose value should appear in the post-`create()` model must either:
- be passed by the caller, or
- come from a column factory that provides a `phpDefault`.

Columns relying solely on a DB-side `DEFAULT` (without a matching `phpDefault`), trigger-set values, and generated columns won't be reflected in the in-memory model. Callers that need those values should refresh explicitly. In practice this is a non-event for existing PHPNomad consumers because all framework-provided default columns flow through the factories updated here.

## Why this is better than the writer-consistent approach

The previous attempt (#21's predecessor, plus the closed PRs in `phpnomad/wordpress-integration#30` and `phpnomad/mysql-db-integration#12`) wrapped post-write reads in a transaction or used a HyperDB hook to force master routing. That works but:

- adds latency to every `create()` even on hosts with no router
- has a serious nested-transaction footgun (silently commits a caller-owned outer transaction on MariaDB)
- only solves the problem for SQL backends with router awareness — useless against MongoDB/Cassandra/Elasticsearch/REST
- adds connection-pinning pressure on routers under load

Hydrating from attributes:

- zero overhead on every host (no transaction, no extra round-trip)
- architecturally eliminates the race rather than mitigating it
- works the same way against any future integration regardless of backend
- matches the pattern WordPress/Eloquent/Doctrine already use

## Tests

- `Column::withPhpDefault` / `getPhpDefault` contract
- `DateCreatedFactory` and `DateModifiedFactory` produce a working `phpDefault`
- `create()` hydrates without calling `query()` (no readback)
- `create()` applies `phpDefaults` for missing columns
- Caller-provided values win over `phpDefaults`

```
PHPUnit 9.6.22
.............                                                     13 / 13 (100%)
OK (13 tests, 34 assertions)
```

PHPStan level 9 clean for the changed files. Pre-existing warnings on `Column.php` (about iterable type specs on the original variadic `$attributes`) are untouched.

## Related

- Closes `phpnomad/wordpress-integration#30` and `phpnomad/mysql-db-integration#12` — those defensive PRs can stay closed; this addresses the underlying problem at the right layer.